### PR TITLE
more phase options

### DIFF
--- a/audioqc
+++ b/audioqc
@@ -163,9 +163,9 @@ class QcTarget
           end
 
           if @mediainfo_out['media']['track'][1]['Channels'] == "2"
-            stereo_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/stereo/i).count
-            dual_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/dual/i).count
-            unless stereo_count + dual_count == signal_chain_count
+            @stereo_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/stereo/i).count
+            @dual_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/dual/i).count
+            unless @stereo_count + @dual_count == signal_chain_count
               @enc_hist_error << "BEXT Coding History channels don't match file"
             end
           end
@@ -206,11 +206,21 @@ class QcTarget
     out_of_phase_frames = []
     phase_frames = []
     @levels = []
+    if ! @dual_count.nil? && ! @stereo_count.nil?
+      if @dual_count > 0
+        phase_limit = Configurations['dualmono_audio_phase_limit']
+      elsif
+        @stereo_count > 1
+        phase_limit = Configurations['stereo_audio_phase_limit']
+      end
+    else
+      phase_limit = Configurations['generic_audio_phase_limit']
+    end
     @ffprobe_out['frames'].each do |frames|
       peaklevel = frames['tags']['lavfi.astats.Overall.Peak_level'].to_f
       audiophase = frames['tags']['lavfi.aphasemeter.phase'].to_f
       phase_frames << audiophase
-      out_of_phase_frames << audiophase if audiophase < Configurations['audio_phase_limit']
+      out_of_phase_frames << audiophase if audiophase < phase_limit
       high_db_frames << peaklevel if peaklevel > Configurations['high_level_warning']
       @levels << peaklevel
     end

--- a/audioqc
+++ b/audioqc
@@ -157,6 +157,12 @@ class QcTarget
     out_of_phase_frames = []
     phase_frames = []
     @levels = []
+    unless @mediainfo_out['media']['track'][0]['extra'].nil? || TARGET_EXTENSION != 'wav'
+      if @mediainfo_out['media']['track'][0]['extra']['bext_Present'] == 'Yes' && @mediainfo_out['media']['track'][0]['Encoded_Library_Settings']
+        @stereo_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/stereo/i).count
+        @dual_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/dual/i).count
+      end
+    end
     if ! @dual_count.nil? && ! @stereo_count.nil?
       if @dual_count > 0
         phase_limit = Configurations['dualmono_audio_phase_limit']
@@ -251,7 +257,7 @@ class QcTarget
     if TARGET_EXTENSION == 'wav'
     @enc_hist_error = []
       unless @mediainfo_out['media']['track'][0]['extra'].nil?
-        if  @mediainfo_out['media']['track'][0]['extra']['bext_Present'] == 'Yes' && @mediainfo_out['media']['track'][0]['Encoded_Library_Settings']
+        if @mediainfo_out['media']['track'][0]['extra']['bext_Present'] == 'Yes' && @mediainfo_out['media']['track'][0]['Encoded_Library_Settings']
           signal_chain_count = @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/A=/).count
           if @mediainfo_out['media']['track'][1]['Channels'] == "1"
             unless @mediainfo_out['media']['track'][0]['Encoded_Library_Settings'].scan(/mono/i).count == signal_chain_count

--- a/audioqc.config
+++ b/audioqc.config
@@ -2,6 +2,8 @@
 
 # Set QC values here
 
-audio_phase_limit: -0.25
+stereo_audio_phase_limit: -0.25
+dualmono_audio_phase_limit: 0.95
+generic_audio_phase_limit: -0.25
 high_level_warning: -2.0
 default_extension: 'wav'


### PR DESCRIPTION
Allows separate settings to be used for acceptable phase levels depending on dual-mono vs stereo inputs (relies on information in BEXT CodingHistory). Uses third default option when expected BEXT CodingHistory info is not present. 