### PR TITLE
Path work

### DIFF
--- a/audioqc
+++ b/audioqc
@@ -166,12 +166,12 @@ class QcTarget
 
   def check_md5
     puts "Verifying embedded MD5 for #{@input_path}"
-    md5_line = `bwfmetaedit --MD5-Verify -v "#{@input_path}" 2>&1`.chomp.chomp.split("\n")[0]
-    if md5_line.include?('MD5, no existing MD5 chunk')
+    md5_output = `bwfmetaedit --MD5-Verify -v "#{@input_path}" 2>&1`.chomp.split("\n")
+    if md5_output.any? {|line| line.include?('MD5, no existing MD5 chunk')}
       @warnings << 'No MD5'
-    elsif md5_line.include?('MD5, failed verification')
+    elsif md5_output.any? {|line| line.include?('MD5, failed verification')}
       @warnings << 'Failed MD5 Verification'
-    elsif ! md5_line.include?('MD5, verified')
+    elsif ! md5_output.any? {|line| line.include?('MD5, verified')}
       @warnings << 'MD5 check unable to be performed'
     end
   end

--- a/audioqc
+++ b/audioqc
@@ -216,13 +216,12 @@ class QcTarget
       end
       get_ffprobe_phase_normalized(@volume_command)
     else
-      ffprobe_command = 'ffprobe -print_format json -threads auto -show_entries frame_tags=lavfi.astats.Overall.Number_of_samples,lavfi.astats.Overall.Peak_level,lavfi.astats.Overall.Max_difference,lavfi.astats.1.Peak_level,lavfi.astats.Overall.Mean_difference,lavfi.astats.Overall.Peak_level,lavfi.aphasemeter.phase,lavfi.r128.I -f lavfi -i "amovie=' + "\\'" + @input_path + "\\'" + ',astats=reset=1:metadata=1,aphasemeter=video=0,ebur128=metadata=1"'
+      ffprobe_command = "ffprobe -print_format json -threads auto -show_entries frame_tags=lavfi.astats.Overall.Number_of_samples,lavfi.astats.Overall.Peak_level,lavfi.astats.Overall.Max_difference,lavfi.astats.1.Peak_level,lavfi.astats.Overall.Mean_difference,lavfi.astats.Overall.Peak_level,lavfi.aphasemeter.phase,lavfi.r128.I -f lavfi -i \"amovie='#{@input_path}'" + ',astats=reset=1:metadata=1,aphasemeter=video=0,ebur128=metadata=1"'
+      ffprobe_command.gsub!(':','\:')
       @ffprobe_out = JSON.parse(`#{ffprobe_command}`)
       @ffprobe_phase = @ffprobe_out
     end
     @total_frame_count = @ffprobe_out['frames'].size
-    # change this to find peak volume for each channel and calculate difference
-    # volume_ratio = peak1 / peak 2
   end
 
   def check_phase

--- a/audioqc
+++ b/audioqc
@@ -195,7 +195,8 @@ class QcTarget
     if @channel_count == "2"
       channel_one_vol = []
       channel_two_vol = []
-      ffprobe_command = 'ffprobe -print_format json -threads auto -show_entries frame_tags=lavfi.astats.Overall.Number_of_samples,lavfi.astats.Overall.Peak_level,lavfi.astats.Overall.Max_difference,lavfi.astats.1.Peak_level,lavfi.astats.2.Peak_level,lavfi.astats.1.Peak_level,lavfi.astats.Overall.Mean_difference,lavfi.astats.Overall.Peak_level,lavfi.r128.I -f lavfi -i "amovie=' + "\\'" + @input_path + "\\'" + ',astats=reset=1:metadata=1,ebur128=metadata=1"'
+      ffprobe_command = "ffprobe -print_format json -threads auto -show_entries frame_tags=lavfi.astats.Overall.Number_of_samples,lavfi.astats.Overall.Peak_level,lavfi.astats.Overall.Max_difference,lavfi.astats.1.Peak_level,lavfi.astats.2.Peak_level,lavfi.astats.1.Peak_level,lavfi.astats.Overall.Mean_difference,lavfi.astats.Overall.Peak_level,lavfi.r128.I -f lavfi -i \"amovie='#{@input_path}'" + ',astats=reset=1:metadata=1,ebur128=metadata=1"'
+      ffprobe_command.gsub!(':','\:')
       @ffprobe_out = JSON.parse(`#{ffprobe_command}`)
       @ffprobe_out['frames'].each do |frame|
         if frame['tags']['lavfi.astats.1.Peak_level'] == '-inf' || frame['tags']['lavfi.astats.2.Peak_level'] == '-inf'


### PR DESCRIPTION
Fixes a parsing issue for MD5 verification on read-only systems and makes ffprobe happier with networked paths with colons in them